### PR TITLE
Use Thymeleaf fragment expression

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,52 +1,49 @@
 <!DOCTYPE html>
 
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<head>
+    <meta charset="UTF-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>DocumentXP</title>
-    <link rel="stylesheet" href="./../chatgptstyles.css">
+    <link href="./../chatgptstyles.css" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@2.0.2"></script>
-  </head>
+</head>
 
-  <body>
-    <div class="card">
-      <h1>XP Voting</h1>
-      <p>Type in your topic title to add it to the proposals list</p>
+<body>
+<div class="card">
+    <h1>XP Voting</h1>
+    <p>Type in your topic title to add it to the proposals list</p>
 
-      <form id="proposalform"
-      action="#"
-      th:action="@{/}"
-      th:object="${proposalsForm}"
-      method="post"
-      >
-      <label>Proposal: <input type="text" th:field="*{topicTitle}" /></label>
-      <input type="submit" value="Submit" />
-      <input type="reset" value="Reset" />
+    <form action="#"
+          id="proposalform"
+          method="post"
+          th:action="@{/}"
+          th:object="${proposalsForm}"
+    >
+        <label>Proposal: <input th:field="*{topicTitle}" type="text"/></label>
+        <input type="submit" value="Submit"/>
+        <input type="reset" value="Reset"/>
     </form>
-  </div>
-  <div class="card">
+</div>
+<div class="card">
     <h2>Proposed topic titles</h2>
 
-    
     <div id="proposallist" th:replace="proposal-list.html"></div>
-    
+
     <!-- <form action="#" th:action="@{/clear}" th:object="${password}" method="post">
       <label>Password: <input type="text" th:field="*{password}"/></label>
       <input type="submit" value="Clear Proposals"/>
     </form> -->
-  </div>
-    <footer>
-      <p>
+</div>
+<footer>
+    <p>
         XP Voting is an open spaces topic proposal and voting app developed using
         XP Principles by Andrzej and Nick. Technologies used: Java, HTMX,
         Thymeleaf, Spring Boot.
-      </p>
-      <p>
-        <a href="https://github.com/nickhumberstone/xpvoting"
-        >Find out more on GitHub</a
-        >
-      </p>
-    </footer>
-  </body>
+    </p>
+    <p>
+        <a href="https://github.com/nickhumberstone/xpvoting">Find out more on GitHub</a>
+    </p>
+</footer>
+</body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -28,7 +28,7 @@
 <div class="card">
     <h2>Proposed topic titles</h2>
 
-    <div id="proposallist" th:replace="proposal-list.html"></div>
+    <div id="proposallist" th:replace="~{proposal-list.html}"></div>
 
     <!-- <form action="#" th:action="@{/clear}" th:object="${password}" method="post">
       <label>Password: <input type="text" th:field="*{password}"/></label>


### PR DESCRIPTION
When the app runs Thymeleaf emits the following warning:

>2024-10-29T21:46:25.174Z  WARN 17624 --- [XP Voting] [nio-8080-exec-2] actStandardFragmentInsertionTagProcessor : [THYMELEAF][http-nio-8080-exec-2][index] Deprecated unwrapped fragment expression "proposal-list.html" found in template index, line 31, col 28. Please use the complete syntax of fragment expressions instead ("~{proposal-list.html}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.

This PR switches to the fragment expression syntax.

Additionally:
* Reformat document